### PR TITLE
Add ExtractTarWithoutTarsums

### DIFF
--- a/cmd/d2r/main.go
+++ b/cmd/d2r/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/vbatts/docker-utils/registry"
-	"github.com/vbatts/docker-utils/version"
+	"github.com/flynn/docker-utils/registry"
+	"github.com/flynn/docker-utils/version"
 )
 
 var (

--- a/cmd/dockertarsum/main.go
+++ b/cmd/dockertarsum/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/vbatts/docker-utils/opts"
-	"github.com/vbatts/docker-utils/sum"
-	"github.com/vbatts/docker-utils/version"
+	"github.com/flynn/docker-utils/opts"
+	"github.com/flynn/docker-utils/sum"
+	"github.com/flynn/docker-utils/version"
 )
 
 func main() {

--- a/registry/extract.go
+++ b/registry/extract.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/docker/docker/graph"
-	"github.com/vbatts/docker-utils/sum"
+	"github.com/flynn/docker-utils/sum"
 )
 
 /*

--- a/registry/extract.go
+++ b/registry/extract.go
@@ -17,6 +17,14 @@ import (
 From a tar input, push it to the registry.Registry r
 */
 func ExtractTar(r *Registry, in io.Reader) error {
+	return extractTar(r, in, true)
+}
+
+func ExtractTarWithoutTarsums(r *Registry, in io.Reader) error {
+	return extractTar(r, in, false)
+}
+
+func extractTar(r *Registry, in io.Reader, tarsums bool) error {
 	t := tar.NewReader(in)
 
 	for {
@@ -60,6 +68,16 @@ func ExtractTar(r *Registry, in io.Reader) error {
 			layer_fh, err := os.Create(r.LayerFileName(hashid))
 			if err != nil {
 				return err
+			}
+			if !tarsums {
+				if _, err = io.Copy(layer_fh, t); err != nil {
+					return err
+				}
+				if err = layer_fh.Close(); err != nil {
+					return err
+				}
+				fmt.Printf("Extracted Layer: %s\n", hashid)
+				continue
 			}
 			json_fh, err := os.Open(r.JsonFileName(hashid))
 			if err != nil {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/registry"
-	"github.com/vbatts/docker-utils/version"
+	"github.com/flynn/docker-utils/version"
 )
 
 type Registry struct {


### PR DESCRIPTION
There is no need for tarsums when generating checksums of the data on disk (e.g. using go-tuf)
