### PR TITLE
registry: Include image ID in ancestry

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -74,11 +74,12 @@ func (r Registry) EnsureRepoReady(name string) error {
 }
 
 func (r Registry) CreateAncestry(hashid string) error {
-	hashes := []string{}
-	// Unmarshal the json for the layer, get the parent
+	// the ancestry starts at the given ID and ends at the scratch layer
+	hashes := []string{hashid}
 
 	thisHash := hashid
 	for {
+		// Unmarshal the json for the layer, get the parent
 		imageJson, err := ioutil.ReadFile(r.JsonFileName(thisHash))
 		if err != nil {
 			return err


### PR DESCRIPTION
This is what the docker-registry does:
https://github.com/docker/docker-registry/blob/master/docker_registry/lib/layers.py#L50-L59
