### PR TITLE
Remove reference to godeps _workspace

### DIFF
--- a/registry/extract.go
+++ b/registry/extract.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/flynn/flynn/Godeps/_workspace/src/github.com/vbatts/docker-utils/sum"
+	"github.com/vbatts/docker-utils/sum"
 )
 
 /*


### PR DESCRIPTION
This will facilitate the move from the `Godeps/_workspace` directory to `vendor/`.
